### PR TITLE
Reword Scope

### DIFF
--- a/scope.md
+++ b/scope.md
@@ -6,22 +6,15 @@ breadcrumbs: true
 
 <!-- !! Remember to also update the index page on change !! -->
 
-> This CNA assigns CVE IDs for all active packages hosted on [Hex.pm](https://hex.pm/)
-> when no other more precise CNA is applicable. It also covers all active projects
-> hosted under the GitHub organizations [@elixir-lang](https://github.com/elixir-lang),
-> [@erlang](https://github.com/erlang), [@erlef-cna](https://github.com/erlef-cna)
-> [@erlef](https://github.com/erlef), [@gleam-lang](https://github.com/gleam-lang),
-> and [@hexpm](https://github.com/hexpm).
+Our CNA assigns CVE IDs for:
 
----
-
-Our CNA assigns CVE IDs for all active packages hosted on
-[Hex.pm](https://hex.pm/) when no other more precise CNA is applicable. We also
-cover all active projects hosted under the following organizations:
-
-- [@elixir-lang](https://github.com/elixir-lang)
-- [@erlang](https://github.com/erlang)
-- [@erlef-cna](https://github.com/erlef-cna)
-- [@erlef](https://github.com/erlef)
-- [@gleam-lang](https://github.com/gleam-lang)
-- [@hexpm](https://github.com/hexpm)
+<blockquote class="blockquote">
+  <p markdown="1">
+    Vulnerabilities in active packages hosted on [Hex.pm](https://hex.pm/), and in
+    active projects hosted under the GitHub organizations
+    [@elixir-lang](https://github.com/elixir-lang), [@erlang](https://github.com/erlang),
+    [@erlef-cna](https://github.com/erlef-cna), [@erlef](https://github.com/erlef),
+    [@gleam-lang](https://github.com/gleam-lang), and [@hexpm](https://github.com/hexpm),
+    unless covered by the scope of another CNA.
+  </p>
+</blockquote>


### PR DESCRIPTION
By request from MITRE:

> **Original scope:**
> This CNA assigns CVE IDs for all active packages hosted on Hex.pm when no other more precise CNA is applicable. It also covers all active projects hosted under the GitHub organizations @elixir-lang, @erlang, @erlef-cna @erlef, @gleam-lang, and @hexpm.
> 
> **Proposed new scope:**
> Vulnerabilities in active packages hosted on Hex.pm, and in active projects hosted under the GitHub organizations @elixir-lang, @erlang, @erlef-cna @erlef, @gleam-lang, and @hexpm, unless covered by the scope of another CNA.