### PR TITLE
Add Sitemap Plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem "webrick", "~> 1.9"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-datapage-generator", "~> 1.4", group: :jekyll_plugins
+gem "jekyll-sitemap", "~> 1.4", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-datapage-generator (~> 1.4)
+  jekyll-sitemap (~> 1.4)
   webrick (~> 1.9)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ plugins:
 - jekyll-remote-theme
 - jekyll-datapage-generator
 - jekyll-include-cache
+- jekyll-sitemap
 
 page_gen-dirs: true
 page_gen:


### PR DESCRIPTION
Enables faster search engine indexing.

Will expose the `/robots.txt` and `/sitemap.xml` URLs.